### PR TITLE
Only add class names if they are non-blank

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "react-pacomo",
-  "version": "0.5.1",
+  "name": "@bronto/react-pacomo",
+  "version": "0.5.2-rc3",
   "description": "Provide structure to your component's CSS.",
   "main": "lib/pacomo.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "description": "Provide structure to your component's CSS.",
   "main": "lib/pacomo.js",
   "scripts": {
-    "compile": "babel --presets es2015,stage-0 -d lib/ src/",
+    "compile": "./node_modules/.bin/babel --presets es2015,stage-0 -d lib/ src/",
     "prepublish": "npm run compile",
-    "test": "npm run compile && mocha --compilers js:babel-core/register"
+    "test": "npm run compile && ./node_modules/.bin/mocha --compilers js:babel-core/register"
   },
   "repository": {
     "type": "git",

--- a/src/pacomo.js
+++ b/src/pacomo.js
@@ -97,8 +97,8 @@ export function transformWithPrefix(strategy, componentFunction) {
   // Prefix all `className` props on the passed in ReactElement object, its
   // children, and elements on `props`.
   //
-  // Optionally prefix with a `rootClass` and postfix with `suffixClass`.
-  function transform(element, rootClass, suffixClasses='') {
+  // Optionally prefix with a `rootClass` and postfix with `suffixClasses`.
+  function transform(element, rootClass, suffixClasses) {
     if (typeof element !== 'object' || element.props.__pacomoSkip) return element
 
     const changes = transformElementProps(
@@ -107,11 +107,15 @@ export function transformWithPrefix(strategy, componentFunction) {
       typeof element.type !== 'function'
     )
 
-    if (element.props.className) {
-      changes.className = `${rootClass || ''} ${prefixedClassNames(strategy, componentFunction, element.props.className)} ${suffixClasses}`
+    // make any necessary class name updates
+    let prefixedClassName = null;
+    const elClassName = element.props.className;
+    if (elClassName) {
+        prefixedClassName = prefixedClassNames(strategy, componentFunction, elClassName);
     }
-    else if (rootClass) {
-      changes.className = `${rootClass} ${suffixClasses}`
+    let newClassNames = classNames(rootClass, prefixedClassName, suffixClasses);
+    if (newClassNames.length > 0) {
+        changes.className = newClassNames;
     }
 
     return (
@@ -142,7 +146,7 @@ export function withStrategy(strategy) {
           props.className
         )
 
-      transformedComponent.displayName = `pacomo(${componentName})`
+      transformedComponent.displayName = `Pacomo(${componentName})`
 
       // Add `className` propType, if none exists
       transformedComponent.propTypes = { className: PropTypes.string, ...componentFunction.propTypes }
@@ -166,7 +170,7 @@ export function withStrategy(strategy) {
         }
       }
 
-      DecoratedComponent.displayName = `pacomo(${componentName})`
+      DecoratedComponent.displayName = `Pacomo(${componentName})`
 
       return DecoratedComponent
     },

--- a/test.js
+++ b/test.js
@@ -1,6 +1,5 @@
 import 'babel-polyfill'
 import {
-    PacomoStrategy,
     prefixedClassNames,
     withPackageName,
     transformWithPrefix

--- a/test.js
+++ b/test.js
@@ -174,7 +174,7 @@ describe('#render', () => {
 
     assert.equal(
       rendered.props.className,
-      'prefix-FullComponent  passedIn'
+      'prefix-FullComponent passedIn'
     )
   })
 
@@ -219,7 +219,7 @@ describe('stateless render', () => {
 
     assert.equal(
       rendered.props.className,
-      'prefix-FullStatelessComponent  passedIn'
+      'prefix-FullStatelessComponent passedIn'
     )
   })
 
@@ -300,7 +300,7 @@ describe('transformWithPrefix', () => {
 
     assert.equal(
       transformed.props.className,
-      ' test-nav '
+      'test-nav'
     )
   })
 
@@ -309,11 +309,11 @@ describe('transformWithPrefix', () => {
 
     assert.equal(
       transformed.props.children[0].props.className,
-      ' test-link1 test-active '
+      'test-link1 test-active'
     )
     assert.equal(
       transformed.props.children[1].props.className,
-      ' test-link2 '
+      'test-link2'
     )
   })
 
@@ -322,7 +322,7 @@ describe('transformWithPrefix', () => {
 
     assert.equal(
       transformed.props.children[0].props.focusable.props.className,
-      ' test-Link '
+      'test-Link'
     )
   })
 


### PR DESCRIPTION
This also stops extra spaces being added around the classname that were always added before.
